### PR TITLE
Add GitHub OTA self-update button (v2.6.0)

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -45,3 +45,10 @@ It should now be homed to position 0, and when you press the open button, it sho
 | Any press while homing | Stops it and sets the position to zero |
 
 Hold-to-run is the child- and elderly-friendly mode: the curtain only moves while you keep the button pressed, so it can't run on its own into a person or a cord, and it never drives past the open or closed ends.
+
+## Updating the firmware
+
+Two ways to update:
+
+- **Over the air, from the device:** open the settings page and, under Diagnostics, press **"Update Firmware (GitHub)"**. The device downloads the latest release for its model straight from GitHub, flashes itself, and reboots — no computer needed. (Requires an internet connection.)
+- **Manually:** download the `*.ota.bin` (for a device already on your network) or `*.factory.bin` (for a fresh USB flash) for your model from the [latest release](https://github.com/Valar-Systems/Ropener/releases/latest) and upload it as before.

--- a/firmware/VAL3000/Ropener-VAL3000-2.6.0.yml
+++ b/firmware/VAL3000/Ropener-VAL3000-2.6.0.yml
@@ -1,6 +1,6 @@
 # =============================================================================
 # Ropener — ESPHome firmware
-# Version: 2.5.0
+# Version: 2.6.0
 # =============================================================================
 #
 # A Wi-Fi connected curtain/cover controller that pulls a poly rope using a
@@ -468,7 +468,7 @@ substitutions:
 
   # Firmware version — single source of truth. Feeds project.version (below) and
   # the "Firmware Version" diagnostic sensor shown on the web UI / in HA.
-  firmware_version: "2.5.0"
+  firmware_version: "2.6.0"
 
   # Physical-button gesture timing (ms). Compile-time, not runtime-tunable.
   #   hold_run_ms  : a press held longer than this engages hold-to-run; shorter
@@ -493,9 +493,19 @@ substitutions:
 #     key: !secret api_key
 api:
 
-# Over-the-air firmware updates via the ESPHome platform.
+# Over-the-air firmware updates. The `esphome` platform handles uploads from the
+# ESPHome dashboard / CLI; the `http_request` platform powers the "Update
+# Firmware (GitHub)" button, which pulls the latest released binary from GitHub.
 ota:
   - platform: esphome
+  - platform: http_request
+
+# HTTP client used by the GitHub OTA button. verify_ssl is off so we don't have
+# to bundle and refresh a CA certificate; the tradeoff is no certificate
+# verification on the download. The timeout is generous (the image is ~1 MB).
+http_request:
+  verify_ssl: false
+  timeout: 10min
 
 # UART logger. By default ESPHome logs one DEBUG line per entity publish, so
 # the chatty `number` / `text_sensor` / `sensor` entities (which re-publish on
@@ -1136,6 +1146,23 @@ button:
             - stepper.set_target:
                 id: driver
                 target: -100000
+
+  # Pull the latest released firmware for this model straight from GitHub and
+  # flash it over the air. Points at the version-less "latest" asset so the URL
+  # never changes between releases; the device downloads, flashes, and reboots.
+  - platform: template
+    name: "Update Firmware (GitHub)"
+    web_server:
+      sorting_weight: 5
+      sorting_group_id: group_diagnostics
+    entity_category: DIAGNOSTIC
+    on_press:
+      - logger.log: "Checking GitHub for the latest firmware..."
+      - ota.http_request.flash:
+          # Version-less "latest" assets (published with every release): the OTA
+          # image plus a text file holding its MD5, which the flash verifies.
+          md5_url: https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3000.ota.bin.md5
+          url: https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3000.ota.bin
 
 
 # -----------------------------------------------------------------------------

--- a/firmware/VAL3100/Ropener-VAL3100-2.6.0.yml
+++ b/firmware/VAL3100/Ropener-VAL3100-2.6.0.yml
@@ -1,6 +1,6 @@
 # =============================================================================
 # Ropener — ESPHome firmware
-# Version: 2.5.0
+# Version: 2.6.0
 # =============================================================================
 #
 # A Wi-Fi connected curtain/cover controller that pulls a poly rope using a
@@ -468,7 +468,7 @@ substitutions:
 
   # Firmware version — single source of truth. Feeds project.version (below) and
   # the "Firmware Version" diagnostic sensor shown on the web UI / in HA.
-  firmware_version: "2.5.0"
+  firmware_version: "2.6.0"
 
   # Physical-button gesture timing (ms). Compile-time, not runtime-tunable.
   #   hold_run_ms  : a press held longer than this engages hold-to-run; shorter
@@ -493,9 +493,19 @@ substitutions:
 #     key: !secret api_key
 api:
 
-# Over-the-air firmware updates via the ESPHome platform.
+# Over-the-air firmware updates. The `esphome` platform handles uploads from the
+# ESPHome dashboard / CLI; the `http_request` platform powers the "Update
+# Firmware (GitHub)" button, which pulls the latest released binary from GitHub.
 ota:
   - platform: esphome
+  - platform: http_request
+
+# HTTP client used by the GitHub OTA button. verify_ssl is off so we don't have
+# to bundle and refresh a CA certificate; the tradeoff is no certificate
+# verification on the download. The timeout is generous (the image is ~1 MB).
+http_request:
+  verify_ssl: false
+  timeout: 10min
 
 # UART logger. By default ESPHome logs one DEBUG line per entity publish, so
 # the chatty `number` / `text_sensor` / `sensor` entities (which re-publish on
@@ -1138,6 +1148,23 @@ button:
             - stepper.set_target:
                 id: driver
                 target: -100000
+
+  # Pull the latest released firmware for this model straight from GitHub and
+  # flash it over the air. Points at the version-less "latest" asset so the URL
+  # never changes between releases; the device downloads, flashes, and reboots.
+  - platform: template
+    name: "Update Firmware (GitHub)"
+    web_server:
+      sorting_weight: 5
+      sorting_group_id: group_diagnostics
+    entity_category: DIAGNOSTIC
+    on_press:
+      - logger.log: "Checking GitHub for the latest firmware..."
+      - ota.http_request.flash:
+          # Version-less "latest" assets (published with every release): the OTA
+          # image plus a text file holding its MD5, which the flash verifies.
+          md5_url: https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3100.ota.bin.md5
+          url: https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3100.ota.bin
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Lets a Ropener update itself: press a button on the settings page and the device pulls the latest released firmware for its model from GitHub and flashes itself over the air — no computer or USB cable needed.

## What it does

Adds an **"Update Firmware (GitHub)"** button (Diagnostics group) to both VAL3000 and VAL3100. On press it downloads the latest release `.ota.bin` for that model, verifies it against a published MD5, flashes, and reboots.

```yaml
ota:
  - platform: esphome
  - platform: http_request
http_request:
  verify_ssl: false
  timeout: 10min
# button -> ota.http_request.flash:
#   md5_url: .../releases/latest/download/Ropener-VAL3000.ota.bin.md5
#   url:     .../releases/latest/download/Ropener-VAL3000.ota.bin
```

## Design notes

- **Stable URL:** points at the version-less `releases/latest/download/` assets so the firmware URL never changes between releases.
- **MD5 required:** `ota.http_request.flash` requires an MD5 to verify the download; we use `md5_url` pointing at a small `.ota.bin.md5` asset.
- **TLS:** GitHub is HTTPS-only and redirects to a CDN; `verify_ssl: false` avoids bundling/refreshing a CA (no cert verification — acceptable for a DIY device). Adds ~120 KB to the image for TLS.
- **Per-model:** each firmware points at its own model's assets.

## ⚠️ Release process change (required)

Every release must now **also** attach four version-less assets, or the button has nothing to pull:
- `Ropener-VAL3000.ota.bin` + `Ropener-VAL3000.ota.bin.md5`
- `Ropener-VAL3100.ota.bin` + `Ropener-VAL3100.ota.bin.md5`

(The button can't self-update devices to *this* release — users flash 2.6.0 once manually, and the button works for 2.6.1+.)

## Testing

- `esphome config` valid + full `esphome compile` clean for both models (HTTPS OTA links in).
- Not yet exercised on hardware (can't trigger a real OTA without a device + a published 2.6.0 release with the version-less assets).

## Changes

- VAL3000 + VAL3100 YAMLs: `http_request` + `ota: http_request` + the button; version 2.5.0 → 2.6.0; renamed to match.
- README: "Updating the firmware" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)