### PR TITLE
v2.6.1: OTA buffer fix, VAL3100 bring-up, Board sensor, web flasher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ firmware/secrets.yaml
 # Firmware binaries are distributed via GitHub Releases, not tracked in git
 firmware/**/*.factory.bin
 firmware/**/*.ota.bin
+firmware/**/*.ota.bin.md5

--- a/firmware/VAL3000/Ropener-VAL3000-2.6.1.yml
+++ b/firmware/VAL3000/Ropener-VAL3000-2.6.1.yml
@@ -1,10 +1,10 @@
 # =============================================================================
 # Ropener — ESPHome firmware
-# Version: 2.6.0
+# Version: 2.6.1
 # =============================================================================
 #
 # A Wi-Fi connected curtain/cover controller that pulls a poly rope using a
-# TMC2209-driven stepper motor on an ESP32-C6. Control it via a browser at
+# TMC2209-driven stepper motor on an ESP32-C3. Control it via a browser at
 # http://ropener-XXXXXX.local (where XXXXXX is the last 3 bytes of the
 # device's MAC address — printed on the serial log at boot). No Home Assistant
 # required. Can also pair with Home Assistant over the native ESPHome API. Supports a 0..1 position
@@ -14,22 +14,22 @@
 # -----------------------------------------------------------------------------
 # Hardware
 # -----------------------------------------------------------------------------
-#   MCU     : ESP32-C6 (esp32-c6-devkitc-1, esp-idf framework)
+#   MCU     : ESP32-C3 (esp32-c3-devkitm-1, esp-idf framework)
 #   Driver  : TMC2209 stepper driver, single-wire UART control (PDN_UART)
 #   Motor   : NEMA-17 stepper, 200 full steps/rev, 8x microstepping = 1600 steps/rev
 #   Gearing : MK7 drive gear, ~3.7699 cm of rope per revolution
 #
 # -----------------------------------------------------------------------------
-# GPIO wiring (ESP32-C6 -> TMC2209 / buttons)
+# GPIO wiring (ESP32-C3 -> TMC2209 / buttons)
 # -----------------------------------------------------------------------------
-#   GPIO0 : UART RX  <- TMC2209 PDN_UART
+#   GPIO0 : INDEX  (TMC2209 step-counter output, informational)
 #   GPIO1 : DIAG   (TMC2209 StallGuard / diagnostic output -> on_stall)
-#   GPIO3 : Button 1  (close / home), active-low pushbutton to GND
-#   GPIO4 : Button 3  (Wi-Fi reset),  active-low pushbutton to GND
-#   GPIO5 : ENN    (TMC2209 enable, active-low)
+#   GPIO3 : Button 2  (open),         active-low pushbutton to GND
+#   GPIO4 : Button 1  (close / home), active-low pushbutton to GND
+#   GPIO5 : UART RX  <- TMC2209 PDN_UART
 #   GPIO6 : UART TX  -> TMC2209 PDN_UART
-#   GPIO7 : INDEX  (TMC2209 step-counter output, informational)
-#   GPIO8 : Button 2  (open),         active-low pushbutton to GND
+#   GPIO7 : Button 3  (Wi-Fi reset),  active-low pushbutton to GND
+#   GPIO8 : ENN    (TMC2209 enable, active-low)
 #
 # -----------------------------------------------------------------------------
 # Position / motion model
@@ -71,18 +71,18 @@
 #   Holding a button to move only runs while held and the motor auto-stops at
 #   the 0 % / 100 % end — it cannot be driven past the limit.
 #
-#   Button 1 (GPIO3):
+#   Button 1 (GPIO4):
 #     - Tap (quick press/release)   : close cover (to 0 %)
 #     - Press and hold              : close while held; auto-stops at 0 %, and
 #                                     stops early on release (hold-to-run)
 #     - Seven quick taps            : start homing
-#   Button 2 (GPIO8):
+#   Button 2 (GPIO3):
 #     - Tap (quick press/release)   : open cover (to 100 %)
 #     - Press and hold              : open while held; auto-stops at 100 %, and
 #                                     stops early on release (hold-to-run)
 #   Button 1 + Button 2 together:
 #     - Hold both for 3 s           : set the current position as home (0)
-#   Button 3 (GPIO4):
+#   Button 3 (GPIO7):
 #     - Long  press (3 s - 10 s)    : clear saved Wi-Fi credentials + reboot
 #
 # -----------------------------------------------------------------------------
@@ -468,7 +468,7 @@ substitutions:
 
   # Firmware version — single source of truth. Feeds project.version (below) and
   # the "Firmware Version" diagnostic sensor shown on the web UI / in HA.
-  firmware_version: "2.6.0"
+  firmware_version: "2.6.1"
 
   # Physical-button gesture timing (ms). Compile-time, not runtime-tunable.
   #   hold_run_ms  : a press held longer than this engages hold-to-run; shorter
@@ -503,9 +503,14 @@ ota:
 # HTTP client used by the GitHub OTA button. verify_ssl is off so we don't have
 # to bundle and refresh a CA certificate; the tradeoff is no certificate
 # verification on the download. The timeout is generous (the image is ~1 MB).
+# The buffers are enlarged from the 512-byte default: GitHub 302-redirects the
+# download to a very long signed CDN URL, and the request/response don't fit in
+# 512 bytes (the esp_http_client reports "Out of buffer" and the OTA fails).
 http_request:
   verify_ssl: false
   timeout: 10min
+  buffer_size_rx: 4096
+  buffer_size_tx: 4096
 
 # UART logger. By default ESPHome logs one DEBUG line per entity publish, so
 # the chatty `number` / `text_sensor` / `sensor` entities (which re-publish on
@@ -557,7 +562,7 @@ web_server:
 # Board / Wi-Fi
 # -----------------------------------------------------------------------------
 esp32:
-  variant: esp32c6
+  variant: esp32c3
   framework:
     type: esp-idf
 
@@ -583,9 +588,7 @@ captive_portal:
 
 # Improv Wi-Fi provisioning over USB serial — lets tools like web.esphome.io
 # push Wi-Fi credentials without editing secrets.yaml or using the hotspot.
-# Note: unlike the ESP32-C3, the ESP32-C6 has Bluetooth LE, so esp32_improv
-# (BLE provisioning) is also available here if desired — serial is kept for
-# simplicity and because it needs no extra app.
+# Note: esp32_improv_ble is not supported on ESP32-C3 with esp-idf.
 improv_serial:
 
 # -----------------------------------------------------------------------------
@@ -688,7 +691,7 @@ esphome:
 # round-trips for the 1 s polled diagnostic sensors.
 uart:
   tx_pin: 6
-  rx_pin: 0
+  rx_pin: 5
   baud_rate: 500000
 
 # -----------------------------------------------------------------------------
@@ -707,8 +710,8 @@ stepper:
     config_dump_include_registers: false    # dump TMC2209 registers in the boot log for debugging
     rsense: 100 mOhm
     vsense: False
-    enn_pin: 5                             # active-low driver enable
-    index_pin: 7                           # step-counter feedback (unused but wired)
+    enn_pin: 8                             # active-low driver enable
+    index_pin: 0                           # step-counter feedback (unused but wired)
     diag_pin: 1                            # StallGuard / fault output -> on_stall
     on_stall:
       - stepper.stop: driver               # halt motion immediately
@@ -763,7 +766,7 @@ binary_sensor:
       sorting_group_id: group_diagnostics
     id: btn1
     pin:
-      number: 3
+      number: 4
       mode: INPUT
       inverted: true
     filters:
@@ -894,7 +897,7 @@ binary_sensor:
       sorting_group_id: group_diagnostics
     id: btn2
     pin:
-      number: 8
+      number: 3
       mode: INPUT
       inverted: true
     filters:
@@ -992,7 +995,7 @@ binary_sensor:
                   - cover.open: ropener_cover
                   - logger.log: "Button 2 tap: opening"
 
-  # Button 3 (GPIO4): Wi-Fi reset.
+  # Button 3 (GPIO7): Wi-Fi reset.
   # Hold 3-10 s to erase the saved Wi-Fi credentials and reboot. A long hold
   # is required (not a quick tap) so the device can't be knocked offline by an
   # accidental press. On reboot the device re-runs Wi-Fi setup: with no
@@ -1006,7 +1009,7 @@ binary_sensor:
       sorting_group_id: group_diagnostics
     id: btn_wifi_reset
     pin:
-      number: 4
+      number: 7
       mode: INPUT
       inverted: true
     filters:
@@ -1163,8 +1166,8 @@ button:
       - ota.http_request.flash:
           # Version-less "latest" assets (published with every release): the OTA
           # image plus a text file holding its MD5, which the flash verifies.
-          md5_url: https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3100.ota.bin.md5
-          url: https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3100.ota.bin
+          md5_url: https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3000.ota.bin.md5
+          url: https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3000.ota.bin
 
 
 # -----------------------------------------------------------------------------

--- a/firmware/VAL3000/Ropener-VAL3000-2.6.1.yml
+++ b/firmware/VAL3000/Ropener-VAL3000-2.6.1.yml
@@ -470,6 +470,10 @@ substitutions:
   # the "Firmware Version" diagnostic sensor shown on the web UI / in HA.
   firmware_version: "2.6.1"
 
+  # Board identity — shown via the "Board" diagnostic sensor so the firmware on a
+  # unit can be matched to its hardware at a glance.
+  board_id: "VAL3000 (ESP32-C3)"
+
   # Physical-button gesture timing (ms). Compile-time, not runtime-tunable.
   #   hold_run_ms  : a press held longer than this engages hold-to-run; shorter
   #                  is treated as a tap. Long enough that a deliberate tap is
@@ -683,6 +687,9 @@ esphome:
     - text_sensor.template.publish:        # surface the firmware version on the web UI / HA
         id: firmware_version_text
         state: "${firmware_version}"
+    - text_sensor.template.publish:        # surface the board model on the web UI / HA
+        id: board_text
+        state: "${board_id}"
 
 # -----------------------------------------------------------------------------
 # UART to TMC2209 (PDN_UART, single-wire)
@@ -1589,6 +1596,19 @@ text_sensor:
     entity_category: DIAGNOSTIC
     web_server:
       sorting_weight: 4
+      sorting_group_id: group_diagnostics
+    update_interval: never
+
+  # Board model (VAL3000 / C3 vs VAL3100 / C6). Static value from ${board_id},
+  # published once at boot — confirm the right firmware is on the right board
+  # straight from the web UI / HA device info.
+  - platform: template
+    name: "Board"
+    id: board_text
+    icon: "mdi:developer-board"
+    entity_category: DIAGNOSTIC
+    web_server:
+      sorting_weight: 6
       sorting_group_id: group_diagnostics
     update_interval: never
 

--- a/firmware/VAL3100/Ropener-VAL3100-2.6.1.yml
+++ b/firmware/VAL3100/Ropener-VAL3100-2.6.1.yml
@@ -1,10 +1,10 @@
 # =============================================================================
 # Ropener — ESPHome firmware
-# Version: 2.6.0
+# Version: 2.6.1
 # =============================================================================
 #
 # A Wi-Fi connected curtain/cover controller that pulls a poly rope using a
-# TMC2209-driven stepper motor on an ESP32-C3. Control it via a browser at
+# TMC2209-driven stepper motor on an ESP32-C6. Control it via a browser at
 # http://ropener-XXXXXX.local (where XXXXXX is the last 3 bytes of the
 # device's MAC address — printed on the serial log at boot). No Home Assistant
 # required. Can also pair with Home Assistant over the native ESPHome API. Supports a 0..1 position
@@ -14,22 +14,22 @@
 # -----------------------------------------------------------------------------
 # Hardware
 # -----------------------------------------------------------------------------
-#   MCU     : ESP32-C3 (esp32-c3-devkitm-1, esp-idf framework)
+#   MCU     : ESP32-C6 (esp32-c6-devkitc-1, esp-idf framework)
 #   Driver  : TMC2209 stepper driver, single-wire UART control (PDN_UART)
 #   Motor   : NEMA-17 stepper, 200 full steps/rev, 8x microstepping = 1600 steps/rev
 #   Gearing : MK7 drive gear, ~3.7699 cm of rope per revolution
 #
 # -----------------------------------------------------------------------------
-# GPIO wiring (ESP32-C3 -> TMC2209 / buttons)
+# GPIO wiring (ESP32-C6 -> TMC2209 / buttons)
 # -----------------------------------------------------------------------------
-#   GPIO0 : INDEX  (TMC2209 step-counter output, informational)
+#   GPIO0 : UART RX  <- TMC2209 PDN_UART
 #   GPIO1 : DIAG   (TMC2209 StallGuard / diagnostic output -> on_stall)
-#   GPIO3 : Button 2  (open),         active-low pushbutton to GND
-#   GPIO4 : Button 1  (close / home), active-low pushbutton to GND
-#   GPIO5 : UART RX  <- TMC2209 PDN_UART
+#   GPIO3 : Button 1  (close / home), active-low pushbutton to GND
+#   GPIO4 : Button 3  (Wi-Fi reset),  active-low pushbutton to GND
+#   GPIO5 : ENN    (TMC2209 enable, active-low)
 #   GPIO6 : UART TX  -> TMC2209 PDN_UART
-#   GPIO7 : Button 3  (Wi-Fi reset),  active-low pushbutton to GND
-#   GPIO8 : ENN    (TMC2209 enable, active-low)
+#   GPIO7 : INDEX  (TMC2209 step-counter output, informational)
+#   GPIO8 : Button 2  (open),         active-low pushbutton to GND
 #
 # -----------------------------------------------------------------------------
 # Position / motion model
@@ -71,18 +71,18 @@
 #   Holding a button to move only runs while held and the motor auto-stops at
 #   the 0 % / 100 % end — it cannot be driven past the limit.
 #
-#   Button 1 (GPIO4):
+#   Button 1 (GPIO3):
 #     - Tap (quick press/release)   : close cover (to 0 %)
 #     - Press and hold              : close while held; auto-stops at 0 %, and
 #                                     stops early on release (hold-to-run)
 #     - Seven quick taps            : start homing
-#   Button 2 (GPIO3):
+#   Button 2 (GPIO8):
 #     - Tap (quick press/release)   : open cover (to 100 %)
 #     - Press and hold              : open while held; auto-stops at 100 %, and
 #                                     stops early on release (hold-to-run)
 #   Button 1 + Button 2 together:
 #     - Hold both for 3 s           : set the current position as home (0)
-#   Button 3 (GPIO7):
+#   Button 3 (GPIO4):
 #     - Long  press (3 s - 10 s)    : clear saved Wi-Fi credentials + reboot
 #
 # -----------------------------------------------------------------------------
@@ -468,7 +468,7 @@ substitutions:
 
   # Firmware version — single source of truth. Feeds project.version (below) and
   # the "Firmware Version" diagnostic sensor shown on the web UI / in HA.
-  firmware_version: "2.6.0"
+  firmware_version: "2.6.1"
 
   # Physical-button gesture timing (ms). Compile-time, not runtime-tunable.
   #   hold_run_ms  : a press held longer than this engages hold-to-run; shorter
@@ -503,9 +503,14 @@ ota:
 # HTTP client used by the GitHub OTA button. verify_ssl is off so we don't have
 # to bundle and refresh a CA certificate; the tradeoff is no certificate
 # verification on the download. The timeout is generous (the image is ~1 MB).
+# The buffers are enlarged from the 512-byte default: GitHub 302-redirects the
+# download to a very long signed CDN URL, and the request/response don't fit in
+# 512 bytes (the esp_http_client reports "Out of buffer" and the OTA fails).
 http_request:
   verify_ssl: false
   timeout: 10min
+  buffer_size_rx: 4096
+  buffer_size_tx: 4096
 
 # UART logger. By default ESPHome logs one DEBUG line per entity publish, so
 # the chatty `number` / `text_sensor` / `sensor` entities (which re-publish on
@@ -557,7 +562,7 @@ web_server:
 # Board / Wi-Fi
 # -----------------------------------------------------------------------------
 esp32:
-  variant: esp32c3
+  variant: esp32c6
   framework:
     type: esp-idf
 
@@ -583,7 +588,9 @@ captive_portal:
 
 # Improv Wi-Fi provisioning over USB serial — lets tools like web.esphome.io
 # push Wi-Fi credentials without editing secrets.yaml or using the hotspot.
-# Note: esp32_improv_ble is not supported on ESP32-C3 with esp-idf.
+# Note: unlike the ESP32-C3, the ESP32-C6 has Bluetooth LE, so esp32_improv
+# (BLE provisioning) is also available here if desired — serial is kept for
+# simplicity and because it needs no extra app.
 improv_serial:
 
 # -----------------------------------------------------------------------------
@@ -686,7 +693,7 @@ esphome:
 # round-trips for the 1 s polled diagnostic sensors.
 uart:
   tx_pin: 6
-  rx_pin: 5
+  rx_pin: 0
   baud_rate: 500000
 
 # -----------------------------------------------------------------------------
@@ -705,8 +712,8 @@ stepper:
     config_dump_include_registers: false    # dump TMC2209 registers in the boot log for debugging
     rsense: 100 mOhm
     vsense: False
-    enn_pin: 8                             # active-low driver enable
-    index_pin: 0                           # step-counter feedback (unused but wired)
+    enn_pin: 5                             # active-low driver enable
+    index_pin: 7                           # step-counter feedback (unused but wired)
     diag_pin: 1                            # StallGuard / fault output -> on_stall
     on_stall:
       - stepper.stop: driver               # halt motion immediately
@@ -761,7 +768,7 @@ binary_sensor:
       sorting_group_id: group_diagnostics
     id: btn1
     pin:
-      number: 4
+      number: 3
       mode: INPUT
       inverted: true
     filters:
@@ -892,7 +899,7 @@ binary_sensor:
       sorting_group_id: group_diagnostics
     id: btn2
     pin:
-      number: 3
+      number: 8
       mode: INPUT
       inverted: true
     filters:
@@ -990,7 +997,7 @@ binary_sensor:
                   - cover.open: ropener_cover
                   - logger.log: "Button 2 tap: opening"
 
-  # Button 3 (GPIO7): Wi-Fi reset.
+  # Button 3 (GPIO4): Wi-Fi reset.
   # Hold 3-10 s to erase the saved Wi-Fi credentials and reboot. A long hold
   # is required (not a quick tap) so the device can't be knocked offline by an
   # accidental press. On reboot the device re-runs Wi-Fi setup: with no
@@ -1004,7 +1011,7 @@ binary_sensor:
       sorting_group_id: group_diagnostics
     id: btn_wifi_reset
     pin:
-      number: 7
+      number: 4
       mode: INPUT
       inverted: true
     filters:
@@ -1161,8 +1168,8 @@ button:
       - ota.http_request.flash:
           # Version-less "latest" assets (published with every release): the OTA
           # image plus a text file holding its MD5, which the flash verifies.
-          md5_url: https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3000.ota.bin.md5
-          url: https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3000.ota.bin
+          md5_url: https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3100.ota.bin.md5
+          url: https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3100.ota.bin
 
 
 # -----------------------------------------------------------------------------

--- a/firmware/VAL3100/Ropener-VAL3100-2.6.1.yml
+++ b/firmware/VAL3100/Ropener-VAL3100-2.6.1.yml
@@ -22,14 +22,15 @@
 # -----------------------------------------------------------------------------
 # GPIO wiring (ESP32-C6 -> TMC2209 / buttons)
 # -----------------------------------------------------------------------------
-#   GPIO0 : UART RX  <- TMC2209 PDN_UART
-#   GPIO1 : DIAG   (TMC2209 StallGuard / diagnostic output -> on_stall)
+#   GPIO0 : UART TX  -> TMC2209 PDN_UART
+#   GPIO1 : UART RX  <- TMC2209 PDN_UART
 #   GPIO3 : Button 1  (close / home), active-low pushbutton to GND
 #   GPIO4 : Button 3  (Wi-Fi reset),  active-low pushbutton to GND
 #   GPIO5 : ENN    (TMC2209 enable, active-low)
-#   GPIO6 : UART TX  -> TMC2209 PDN_UART
+#   GPIO6 : DIAG   (TMC2209 StallGuard / diagnostic output -> on_stall)
 #   GPIO7 : INDEX  (TMC2209 step-counter output, informational)
-#   GPIO8 : Button 2  (open),         active-low pushbutton to GND
+#   GPIO19: Button 2  (open),         active-low pushbutton to GND
+#   GPIO23: Status LED (device health indicator, active-high)
 #
 # -----------------------------------------------------------------------------
 # Position / motion model
@@ -76,7 +77,7 @@
 #     - Press and hold              : close while held; auto-stops at 0 %, and
 #                                     stops early on release (hold-to-run)
 #     - Seven quick taps            : start homing
-#   Button 2 (GPIO8):
+#   Button 2 (GPIO19):
 #     - Tap (quick press/release)   : open cover (to 100 %)
 #     - Press and hold              : open while held; auto-stops at 100 %, and
 #                                     stops early on release (hold-to-run)
@@ -470,6 +471,10 @@ substitutions:
   # the "Firmware Version" diagnostic sensor shown on the web UI / in HA.
   firmware_version: "2.6.1"
 
+  # Board identity — shown via the "Board" diagnostic sensor so the firmware on a
+  # unit can be matched to its hardware at a glance.
+  board_id: "VAL3100 (ESP32-C6)"
+
   # Physical-button gesture timing (ms). Compile-time, not runtime-tunable.
   #   hold_run_ms  : a press held longer than this engages hold-to-run; shorter
   #                  is treated as a tap. Long enough that a deliberate tap is
@@ -685,6 +690,9 @@ esphome:
     - text_sensor.template.publish:        # surface the firmware version on the web UI / HA
         id: firmware_version_text
         state: "${firmware_version}"
+    - text_sensor.template.publish:        # surface the board model on the web UI / HA
+        id: board_text
+        state: "${board_id}"
 
 # -----------------------------------------------------------------------------
 # UART to TMC2209 (PDN_UART, single-wire)
@@ -692,8 +700,8 @@ esphome:
 # 500 kbaud is well within the TMC2209's tolerance and gives quick register
 # round-trips for the 1 s polled diagnostic sensors.
 uart:
-  tx_pin: 6
-  rx_pin: 0
+  tx_pin: 0
+  rx_pin: 1
   baud_rate: 500000
 
 # -----------------------------------------------------------------------------
@@ -714,7 +722,7 @@ stepper:
     vsense: False
     enn_pin: 5                             # active-low driver enable
     index_pin: 7                           # step-counter feedback (unused but wired)
-    diag_pin: 1                            # StallGuard / fault output -> on_stall
+    diag_pin: 6                            # StallGuard / fault output -> on_stall
     on_stall:
       - stepper.stop: driver               # halt motion immediately
       - if:
@@ -899,7 +907,7 @@ binary_sensor:
       sorting_group_id: group_diagnostics
     id: btn2
     pin:
-      number: 8
+      number: 19
       mode: INPUT
       inverted: true
     filters:
@@ -1594,6 +1602,19 @@ text_sensor:
       sorting_group_id: group_diagnostics
     update_interval: never
 
+  # Board model (VAL3000 / C3 vs VAL3100 / C6). Static value from ${board_id},
+  # published once at boot — confirm the right firmware is on the right board
+  # straight from the web UI / HA device info.
+  - platform: template
+    name: "Board"
+    id: board_text
+    icon: "mdi:developer-board"
+    entity_category: DIAGNOSTIC
+    web_server:
+      sorting_weight: 6
+      sorting_group_id: group_diagnostics
+    update_interval: never
+
 # -----------------------------------------------------------------------------
 # Motion-completion poll
 # -----------------------------------------------------------------------------
@@ -1702,3 +1723,24 @@ sensor:
     lambda: return id(driver)->read_register(SG_RESULT);
     update_interval: 1s
     entity_category: DIAGNOSTIC
+
+# -----------------------------------------------------------------------------
+# Status LED (VAL3100 only)
+# -----------------------------------------------------------------------------
+# Onboard LED on GPIO23. Uses ESPHome's `status_led`, which reflects device
+# health automatically with no custom logic:
+#   off        - connected and healthy
+#   slow blink - warning (Wi-Fi / API not connected, or in setup / AP mode)
+#   fast blink - error
+# Assumes the LED is active-high (lit when GPIO23 is driven high). If it's wired
+# active-low (lit when the pin is low), set `inverted: true` under `pin:`.
+light:
+  - platform: status_led
+    name: "Status LED"
+    id: status_led_light
+    web_server:
+      sorting_weight: 5
+      sorting_group_id: group_diagnostics
+    pin:
+      number: GPIO23
+      inverted: false

--- a/flash/index.html
+++ b/flash/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Flash Ropener Firmware</title>
+  <!-- ESP Web Tools: reads the connected chip and flashes the matching build from manifest.json -->
+  <script type="module" src="https://unpkg.com/esp-web-tools@10/dist/web/install-button.js?module"></script>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; max-width: 40rem; margin: 3rem auto; padding: 0 1rem; line-height: 1.5; color: #1c2128; }
+    h1 { font-size: 1.6rem; }
+    button { font-size: 1rem; padding: 0.6rem 1.3rem; border-radius: 6px; border: 0; background: #1f6feb; color: #fff; cursor: pointer; }
+    button:hover { background: #1a5fd0; }
+    .note { color: #57606a; font-size: 0.9rem; }
+    ul { color: #24292f; }
+    a { color: #1f6feb; }
+  </style>
+</head>
+<body>
+  <h1>⚙️ Flash your Ropener</h1>
+  <p>Plug the device into this computer over USB, then click <b>Install</b>. The
+     installer auto-detects your board by its chip and flashes the matching firmware:</p>
+  <ul>
+    <li><b>VAL3000</b> — ESP32-C3</li>
+    <li><b>VAL3100</b> — ESP32-C6</li>
+  </ul>
+
+  <esp-web-install-button manifest="manifest.json">
+    <button slot="activate">Install Ropener Firmware</button>
+    <span slot="unsupported" class="note">⚠️ Your browser can't flash — use desktop <b>Chrome</b> or <b>Edge</b>.</span>
+    <span slot="not-allowed" class="note">⚠️ This page must be served over <b>HTTPS</b> (or localhost) to flash.</span>
+  </esp-web-install-button>
+
+  <p class="note">After flashing, the installer can also connect the device to your Wi-Fi.
+     Need help? See the <a href="https://github.com/Valar-Systems/Ropener/wiki/Firmware-Guide">Firmware Guide</a>.</p>
+</body>
+</html>

--- a/flash/manifest.json
+++ b/flash/manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "Ropener",
+  "version": "2.6.1",
+  "home_assistant_domain": "esphome",
+  "new_install_prompt_erase": false,
+  "builds": [
+    {
+      "chipFamily": "ESP32-C3",
+      "parts": [
+        {
+          "path": "https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3000.factory.bin",
+          "offset": 0
+        }
+      ]
+    },
+    {
+      "chipFamily": "ESP32-C6",
+      "parts": [
+        {
+          "path": "https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3100.factory.bin",
+          "offset": 0
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Brings `ota-buffer-fix` into `main` as the **v2.6.1** release. (Latest published release is v2.6.0; 2.6.1 was bumped in the YAMLs but never released, so all of this lands as 2.6.1.)

## Changes
- **GitHub OTA "Out of buffer" fix** — enlarge HTTP client buffers so the in-browser self-update completes.
- **VAL3100 hardware bring-up** — correct the pin map to match the real board: UART TX=GPIO0, RX=GPIO1, DIAG=GPIO6, Button 2=GPIO19; status LED on GPIO23. Fixes the "Reading from UART timed out" / no-motor-current symptom; validated on hardware.
- **Board diagnostic sensor** (both boards) — shows `VAL3000 (ESP32-C3)` / `VAL3100 (ESP32-C6)` so the right firmware can be confirmed on the right hardware.
- **Web flasher** (`flash/`) — ESP Web Tools manifest + install page that auto-selects the binary by chip family.

## Release plan
After merge, v2.6.1 is tagged from `main` with versioned + stable `factory`/`ota` binaries and refreshed `*.ota.bin.md5` for both boards (self-update + web-flasher assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)