### PR TITLE
Fix web flasher CORS: serve firmware bins same-origin

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - "flash/**"
       - ".github/workflows/pages.yml"
+  # Re-deploy whenever a new release is published, so the flasher serves the
+  # latest firmware bins (they're fetched from the release at build time).
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -28,6 +32,17 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+      # Pull the latest release's factory images into flash/ so the flasher
+      # serves them same-origin. GitHub release downloads send no CORS headers,
+      # so ESP Web Tools can't fetch them cross-origin from the Pages site.
+      - name: Fetch firmware binaries from the latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download --repo "${{ github.repository }}" \
+            --pattern 'Ropener-VAL3000.factory.bin' \
+            --pattern 'Ropener-VAL3100.factory.bin' \
+            --dir flash --clobber
       - uses: actions/configure-pages@v5
         with:
           enablement: true

--- a/flash/manifest.json
+++ b/flash/manifest.json
@@ -8,7 +8,7 @@
       "chipFamily": "ESP32-C3",
       "parts": [
         {
-          "path": "https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3000.factory.bin",
+          "path": "Ropener-VAL3000.factory.bin",
           "offset": 0
         }
       ]
@@ -17,7 +17,7 @@
       "chipFamily": "ESP32-C6",
       "parts": [
         {
-          "path": "https://github.com/Valar-Systems/Ropener/releases/latest/download/Ropener-VAL3100.factory.bin",
+          "path": "Ropener-VAL3100.factory.bin",
           "offset": 0
         }
       ]


### PR DESCRIPTION
## Problem
The live flasher at https://valar-systems.github.io/Ropener/ detects the board fine, but **Install fails with "Failed to fetch."**

Root cause is **CORS**. ESP Web Tools `fetch()`es the `.factory.bin` from the GitHub release, but release downloads send **no `Access-Control-Allow-Origin` header** on any hop:

```
github.com/.../releases/latest/download/...   302  (no ACAO)
github.com/.../releases/download/v2.6.1/...    302  (no ACAO)
release-assets.githubusercontent.com/...       200  (no ACAO)
```

So the browser blocks the cross-origin fetch from `valar-systems.github.io`. Board detection still works because that's USB, not a network fetch.

## Fix
Serve the bins from the **same origin** as the flasher:

- **`flash/manifest.json`** — relative paths (`Ropener-VAL3000.factory.bin`, `Ropener-VAL3100.factory.bin`) that resolve to the Pages origin.
- **`.github/workflows/pages.yml`** — downloads the latest release's factory bins into `flash/` at build time via `gh release download`, so binaries stay out of git but ship on the Pages origin. Also re-deploys automatically on `release: published` so the flasher always serves the latest firmware.

## After merge
Merging to `main` triggers the Pages deploy. Then re-test Install on a real board — the download should now succeed.