### PR TITLE
pages: don't fail Pages deploy on branch-cut releases

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,15 @@ concurrency:
 
 jobs:
   deploy:
+    # The github-pages environment only allows deployments from the default
+    # branch. A release published from a feature branch runs from its tag ref
+    # and would be rejected at the environment gate (a hard failure). So for
+    # release events, only deploy when the release was cut from the default
+    # branch (the normal flow); otherwise skip cleanly. You can still update the
+    # flasher for a branch-cut release via workflow_dispatch from main.
+    if: >-
+      github.event_name != 'release' ||
+      github.event.release.target_commitish == github.event.repository.default_branch
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Problem
Publishing **v2.6.2** triggered the Pages deploy from the release's tag ref (`v2.6.2`, on the `release-2.6.2` branch). The `github-pages` environment only allows deployments from the **default branch**, so `actions/deploy-pages` was rejected at the environment gate and the run **failed hard** (before any step ran). Re-running it failed identically.

## Fix
Guard the `deploy` job: on `release` events, only deploy when the release was cut from the default branch (the normal flow). A branch-cut release now **skips cleanly** (neutral, not a red failure). The flasher can still be refreshed for such a release via `workflow_dispatch` from `main`.

No change to the normal paths (push to `main`, `workflow_dispatch`, or a release cut from `main`).