### PR TITLE
docs: update hardware docs for v1.1 plastics revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ There is a carriage attached to the back of each curtain panel. A string runs th
 
 At the heart of the device is our custom PCB which uses an ESP32 and Trinamic TMC2209 stepper driver. The motor is dead silent.
 
+The latest **v1.1** hardware revision uses a smaller-diameter MK8 drive gear that boosts the pull strength from 11 lb to **15 lb**, swaps to a single larger bearing per arm (fewer parts), and uses pre-cut PTFE tubes. See the [hardware notes](hardware/README.md) for details.
+
 ## Will it work on your curtains?
 
 This works on the following curtains:
@@ -47,7 +49,7 @@ We've created a hardware kit that includes everything. If you source the parts i
 
 ## How to 3D print it
 
-Go to the repo folder "hardware" -> "Plastics" -> "platter"
+The current revision is **v1.1**. Open the print plate at [hardware/plastics/v1.1/platter-all-v1.1.3mf](hardware/plastics/v1.1/platter-all-v1.1.3mf), or print the individual `.step` files in that folder. The earlier [v1.0](hardware/plastics/v1.0) files remain for anyone who already built one.
 
 
 ## How to install it

--- a/docs/BOM-V2.0.md
+++ b/docs/BOM-V2.0.md
@@ -1,5 +1,7 @@
 # BOM V2.0
 
+> Reflects the **v1.1** hardware. What changed from v1.0: a smaller-diameter **MK8** drive gear (pull strength 11 lb → 15 lb), **one larger 633ZZ bearing per arm** instead of two small bearings, and **pre-cut PTFE tubes** (no razor-cutting). Quantities are per unit.
+
 ## Body Assembly
 | Part | Amount | Short Description |
 | :--- | :---: | :---: |
@@ -12,14 +14,14 @@
 | M3 Square Nut | 1 ||
 | M3 x 16mm Screw Buttonhead | 2 ||
 | M3 x 10 mm Screw Flathead | 2 ||
-| Gear | 1 |MK7|
-| Bearing | 2 |7mm x 3mm x 3mm|
+| Gear | 1 | MK8 (5mm bore, 9mm OD) |
+| Bearing | 2 | 633ZZ, 3mm x 13mm x 5mm |
 
 ## Curtain Assembly
 
 | Part | Amount | Short Description |
 | :--- | :---: | :---: |
-| PTFE tubing 3mm ID x 5mm OD | 1 | 290mm length required |
+| PTFE tubing 3mm ID x 5mm OD (pre-cut) | 6 | 2 x 10mm, 2 x 40mm, 2 x 70mm |
 | M3 x 10mm Screw Self-tapping | 11 ||
 | M3 Square Nut | 1 ||
 | M3 x 12 mm Screw Flathead | 1 ||
@@ -36,6 +38,5 @@
 ## Assembly Tools Required
 | Part | Amount | Short Description |
 | :--- | :---: | :---: |
-| Razor | 1 | To cut the length of PTFE tubing|
 | Screw driver Phillips No. 1  | 1 ||
 | Hex driver 2mm | 1 ||

--- a/docs/make_bom.py
+++ b/docs/make_bom.py
@@ -183,8 +183,8 @@ bom_table([
     ("M3 square nut", 1, ""),
     ("M3 × 16 mm screw, button head", 2, ""),
     ("M3 × 10 mm screw, flat head", 2, ""),
-    ("Gear", 1, "MK7"),
-    ("Bearing", 2, "7 mm × 3 mm × 3 mm"),
+    ("Gear", 1, "MK8 (5 mm bore, 9 mm OD)"),
+    ("Bearing", 2, "633ZZ, 3 mm × 13 mm × 5 mm"),
 ])
 
 # ---------------------------------------------------------------------------
@@ -192,7 +192,7 @@ bom_table([
 # ---------------------------------------------------------------------------
 doc.add_heading("Curtain Assembly", level=1)
 bom_table([
-    ("PTFE tubing, 3 mm ID × 5 mm OD", 1, "290 mm length required"),
+    ("PTFE tubing, 3 mm ID × 5 mm OD (pre-cut)", 6, "2 × 10 mm, 2 × 40 mm, 2 × 70 mm"),
     ("M3 × 10 mm screw, self-tapping", 11, ""),
     ("M3 square nut", 1, ""),
     ("M3 × 12 mm screw, flat head", 1, ""),
@@ -212,7 +212,6 @@ bom_table([
 # ---------------------------------------------------------------------------
 doc.add_heading("Assembly Tools Required", level=1)
 bom_table([
-    ("Razor", 1, "To cut the length of PTFE tubing"),
     ("Screwdriver, Phillips No. 1", 1, ""),
     ("Hex driver, 2 mm", 1, ""),
 ])

--- a/docs/wiki-Build-Guide.md
+++ b/docs/wiki-Build-Guide.md
@@ -6,6 +6,13 @@
 
 Assembling a Ropener takes about **20 minutes** with three common hand tools — no soldering. It comes together in three stages: the **motor body**, the **curtain-rail carriages**, and **attaching it to your curtains**. Follow whichever guide below suits you — they all cover the same build.
 
+> 🆕 **New in v1.1** — This guide covers the current **v1.1** hardware:
+> - **Stronger pull (11 lb → 15 lb)** from a smaller-diameter **MK8** drive gear (replaces the MK7).
+> - **One larger 633ZZ bearing (3 × 13 × 5 mm) per arm** instead of two small bearings.
+> - **Pre-cut PTFE tubes** (10 / 40 / 70 mm) — no measuring or razor-cutting.
+>
+> Print from [`hardware/plastics/v1.1`](https://github.com/Valar-Systems/Ropener/tree/main/hardware/plastics/v1.1). The v1.0 files remain in the repo for anyone who already built one.
+
 ## How to build
 
 | Guide | Best for |
@@ -82,14 +89,14 @@ Everything the build needs is below. For the full, maintained list see the [Bill
 | Cable extension | as needed |
 | 3M Command Strips | 4 |
 | 1.6 mm rope | 30 ft |
-| PTFE tubing | 250 mm |
+| PTFE tubing (pre-cut: 2 × 10 mm, 2 × 40 mm, 2 × 70 mm) | 6 |
 | M3 square nut | 4 |
 | M3 × 35 mm button-head screw | 3 |
 | V-groove pulley | 1 |
 | M3 × 10 mm flat-head screw | 2 |
 | M3 × 15 mm button-head screw | 3 |
-| Bearing | 4 |
-| MK7 drive gear | 1 |
+| Bearing (633ZZ, 3 × 13 × 5 mm) | 2 |
+| MK8 drive gear | 1 |
 | Zip tie | 4 |
 | M3 × 10 mm thread-forming screw | 23 |
 
@@ -126,8 +133,8 @@ This device works on the following curtain types.
 <!-- 📷 media/build-guide/08-drive-pulley.png — drive pulley on motor shaft -->
 4. **Attach the drive pulley.** Fit it onto the motor shaft. You'll fine-tune its position later.
 
-<!-- 📷 media/build-guide/09-arms.png — arm with M3×12mm button head (red), two bearings (green), M3 square nut (orange) -->
-5. **Assemble the two arms.** Each arm uses an **M3 × 12 mm button-head screw**, **two bearings**, and an **M3 square nut**. Build both arms the same way.
+<!-- 📷 media/build-guide/09-arms.png — arm with M3×12mm button head (red), one 633ZZ bearing (green), M3 square nut (orange) -->
+5. **Assemble the two arms.** Each arm uses an **M3 × 12 mm button-head screw**, **one 633ZZ bearing (3 × 13 × 5 mm)**, and an **M3 square nut**. Build both arms the same way.
 
 <!-- 📷 media/build-guide/10-arms-connector.png — plastic connector + both arms on motor, 2× M3×30mm screws -->
 6. **Attach the arms to the motor.** Fasten the plastic connector and **both arms** to the motor using **two M3 × 30 mm screws**.
@@ -149,13 +156,13 @@ This device works on the following curtain types.
 
 <!-- 📷 media/build-guide/15-setup-overview.png — rail layout: pulley, 1-screw carriage, 2-screw carriage, motor side -->
 
-**Cut the PTFE tube** to the lengths below with a razor — two of each:
+The **PTFE tubes come pre-cut** — no cutting needed. You'll have **two of each length**:
 
-| Length | Quantity |
-| --- | --- |
-| Short | 2 |
-| Medium | 2 |
-| Long | 2 |
+| Length | Size | Quantity |
+| --- | --- | --- |
+| Short | 10 mm | 2 |
+| Medium | 40 mm | 2 |
+| Long | 70 mm | 2 |
 
 <!-- 📷 media/build-guide/16-long-tubes.png — 2 long tubes placed, top plastic attached with 2 screws -->
 1. **Long tubes.** Place the **two long tubes**, then attach the top plastic using **two M3 thread-forming screws**.

--- a/docs/wiki-Home.md
+++ b/docs/wiki-Home.md
@@ -31,6 +31,7 @@ Control it from its built-in web page, the on-device buttons, or your smart home
 ## ✨ Why Ropener
 
 - **🔇 Silent** — Trinamic TMC2209 stepper driver.
+- **💪 Strong** — v1.1's MK8 drive gear pulls up to **15 lb** (up from 11 lb).
 - **📶 Wi-Fi built in** — control from any browser at `http://ropener-XXXXXX.local`, no cloud needed.
 - **🏠 Smart-home ready** — Home Assistant via ESPHome; Alexa, Apple & Google via Matterbridge.
 - **⏰ Scheduling** — set daily open/close times, or any position in between.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -1,3 +1,12 @@
+# What's new in v1.1
+The current hardware revision is **v1.1**. Print from [`hardware/plastics/v1.1`](plastics/v1.1) (the [v1.0](plastics/v1.0) files remain for anyone who already built one).
+
+- **Stronger pull (11 lb → 15 lb)** — a smaller-diameter **MK8** drive gear replaces the MK7.
+- **Fewer parts** — each arm now uses **one larger 633ZZ bearing (3 × 13 × 5 mm)** instead of two small bearings.
+- **Pre-cut PTFE tubes** — tubes now ship pre-cut to **10 / 40 / 70 mm** (two of each), so there's no measuring or razor-cutting during the build.
+
+The plastics changed slightly to suit the new tube lengths; otherwise assembly is the same.
+
 # Instructions
 Image build guide can be found [here](https://canva.link/tmpoyau5pfkddx3).\
 Video build guide can be found [here](https://youtu.be/uowt6jLxNso).\
@@ -15,13 +24,13 @@ Or you can source the parts below.
 | [Cable extension](https://valarsystems.com/products/barrel-plug-extension-cable?variant=43389605609531)|As needed|
 | [3M Command Strips](https://valarsystems.com/products/3m-command-strips)|4|
 | [Rope](https://valarsystems.com/products/rope)|30ft|
-| [PTFE Tubing](https://valarsystems.com/products/ptfe-tube)|250mm|
+| [PTFE Tubing (pre-cut: 2×10mm, 2×40mm, 2×70mm)](https://valarsystems.com/products/ptfe-tube)|6|
 | [M3 Square Nut](https://valarsystems.com/products/m3-square-nut)|4|
 | [M3x35mm Button Head Screw](https://valarsystems.com/products/m3-x-35mm-button-head-screw)|3|
 | [V-Groove Pulley](https://valarsystems.com/products/v-groove-pulley)|1|
 | [M3x10mm Flat Head Screw](https://valarsystems.com/products/m3-x-35mm-button-head-screw-copy)|2|
 | [M3x15mm Button Head Screw](https://valarsystems.com/products/m3-x-10mm-thread-forming-screw-copy)|3|
-| [Bearing](https://valarsystems.com/products/bearing)|4|
-| [MK7 Drive Gear](https://valarsystems.com/products/ropener-drive-gear)|1|
+| [633ZZ Bearing (3×13×5mm)](https://valarsystems.com/products/bearing)|2|
+| [MK8 Drive Gear](https://valarsystems.com/products/ropener-drive-gear)|1|
 | [Zip Tie](https://valarsystems.com/products/zip-tie)|4|
 | [M3x10mm Thread Forming Screw](https://valarsystems.com/products/m3-x-10mm-thread-forming-screw)|23|


### PR DESCRIPTION
Document the v1.1 hardware change across the README, hardware README, BOM, and wiki source pages:

- Drive gear MK7 -> MK8 (smaller diameter): pull strength 11 lb -> 15 lb
- Bearings: 4x small (7x3x3mm) -> 2x 633ZZ (3x13x5mm), one per arm
- PTFE tubing now pre-cut (2x10mm, 2x40mm, 2x70mm) instead of cut-to-length; removed the razor from the tool list and the cut-to-length build step
- Point 3D-print instructions at hardware/plastics/v1.1; v1.0 kept as legacy

Also updated make_bom.py so a regen produces a matching .docx/.pdf (branded binaries not regenerated in this commit).