### PR TITLE
Restore Ropener stall handling lost in the valar-core rewire (v2.7.0 regression)

### DIFF
--- a/firmware/VAL3000/Ropener-VAL3000.yml
+++ b/firmware/VAL3000/Ropener-VAL3000.yml
@@ -12,7 +12,9 @@ substitutions:
   log_uart: "USB_SERIAL_JTAG"
   ota_repo: "Valar-Systems/Ropener"
   ota_asset: "Ropener-VAL3000"
-  fw_version: "2.7.0"
+  # "dev" for local/branch builds; the release workflow overrides it with the
+  # git tag (-s fw_version) so shipped units report the version they run.
+  fw_version: "dev"
   pin_uart_tx: "6"
   pin_uart_rx: "5"
   pin_enn: "8"

--- a/firmware/VAL3100/Ropener-VAL3100.yml
+++ b/firmware/VAL3100/Ropener-VAL3100.yml
@@ -13,7 +13,9 @@ substitutions:
   log_uart: "USB_SERIAL_JTAG"
   ota_repo: "Valar-Systems/Ropener"     # field units self-update from Ropener's own releases
   ota_asset: "Ropener-VAL3100"
-  fw_version: "2.7.0"
+  # "dev" for local/branch builds; the release workflow overrides it with the
+  # git tag (-s fw_version) so shipped units report the version they run.
+  fw_version: "dev"
   pin_uart_tx: "0"
   pin_uart_rx: "1"
   pin_enn: "5"

--- a/firmware/common/ropener-product.yaml
+++ b/firmware/common/ropener-product.yaml
@@ -29,6 +29,19 @@ substitutions:
 # stepper; here we resync the derived step count and restore the saved position
 # so the cover comes up accurate without a re-home. (scheduling re-applies
 # tz/location at priority -100, after this.)
+# The API's reboot_timeout defaults to 15 min: if no *API* client connects in
+# that window the device reboots. It counts native-API clients only — a browser
+# on the web UI is not one. The Ropener is sold as working without Home
+# Assistant, so a customer driving it purely from the browser got a controller
+# that rebooted every 15 minutes, stopping the curtain mid-travel if it happened
+# to be moving. 0 = never reboot for lack of a client.
+#
+# Trade-off: this also removes the watchdog that recovers a wedged API
+# connection. Acceptable here — the users it was rebooting are the ones not
+# using the API at all — and safe_mode still covers boot loops.
+api:
+  reboot_timeout: 0s
+
 esphome:
   on_boot:
     - priority: 400.0

--- a/firmware/common/ropener-product.yaml
+++ b/firmware/common/ropener-product.yaml
@@ -58,6 +58,40 @@ globals:
   - { id: b1_tap_count,   type: int,      restore_value: no, initial_value: '0' }
   - { id: b1_last_tap_ms, type: uint32_t, restore_value: no, initial_value: '0' }
 
+# --- Stall handling (homing) ------------------------------------------------
+# The Ropener homes sensorlessly: drive at the closed end until StallGuard fires,
+# and treat THAT stall as position 0. Core's default on_stall zeroes the position
+# unconditionally, which is wrong here — a stall mid-travel (curtain snags) would
+# silently redefine that spot as home and corrupt the cover's position reference.
+#
+# `!extend` APPENDS to core's action list rather than replacing it, so extending
+# alone would leave core's unconditional zeroing firing before ours. The two
+# entries below are deliberate and order-dependent: the first deletes core's
+# handler outright, the second installs the Ropener's conditional one. Verified
+# against the resolved config — exactly one on_stall survives. Keep both.
+stepper:
+  - id: !extend driver
+    on_stall: !remove
+  - id: !extend driver
+    on_stall:
+      - stepper.stop: driver
+      - if:
+          condition:
+            lambda: 'return id(global_state) == 3;'
+          then:
+            - stepper.report_position: { id: driver, position: 0 }
+            - stepper.set_target: { id: driver, target: 0 }
+            - globals.set: { id: global_state, value: "0" }
+            - cover.template.publish: { id: ropener_cover, current_operation: IDLE }
+            - logger.log: "Homed cover"
+          # Stall outside homing (curtain snagged, or it hit the far end): stop
+          # and settle the UI back to idle, but LEAVE the position alone — this
+          # point is not home, and zeroing here is what corrupted v2.7.0.
+          else:
+            - globals.set: { id: global_state, value: "0" }
+            - cover.template.publish: { id: ropener_cover, current_operation: IDLE }
+            - logger.log: "Stall detected outside homing — motor stopped, position unchanged"
+
 script:
   # Recompute the derived step cache from the persisted centimeters (one place).
   - id: recompute_distance
@@ -297,6 +331,27 @@ binary_sensor:
               esphome::wifi::global_wifi_component->clear_sta();
           - delay: 1s
           - lambda: "App.safe_reboot();"
+
+# --- Preserve the shipped "Motor Direction" option strings --------------------
+# Field units (and any Home Assistant automation that selects a direction) know
+# this option as "Reversed ↺" — the glyph is part of the string, not decoration.
+# valar-core dropped it to a plain "Reversed", which would silently break those
+# automations and leave existing units holding an option that no longer exists.
+# `options` is a list, so !extend would APPEND and yield three choices; remove
+# then re-add instead. `lambda` is a scalar, so extending overwrites it cleanly.
+# Core's set_action matches on `x.find("Reversed")`, which still hits — no
+# override needed there.
+select:
+  - id: !extend sel_direction
+    options: !remove
+  - id: !extend sel_direction
+    options:
+      - "Normal"
+      - "Reversed ↺"
+    lambda: |-
+      if (id(global_stepper_direction) == esphome::tmc2209::ShaftDirection::COUNTERCLOCKWISE)
+        return std::string("Reversed ↺");
+      return std::string("Normal");
 
 # --- Rename core tuning entities to Ropener's existing entity_ids -------------
 number:

--- a/firmware/common/ropener-product.yaml
+++ b/firmware/common/ropener-product.yaml
@@ -388,6 +388,10 @@ cover:
   - platform: template
     id: ropener_cover
     name: Ropener
+    # A curtain draws sideways, not up and down. With no device_class the UI
+    # falls back to generic up/down arrows; "curtain" gets the horizontal
+    # open/close controls (and the right icon in Home Assistant).
+    device_class: curtain
     web_server: { sorting_weight: 1, sorting_group_id: group_control }
     has_position: true
     assumed_state: false

--- a/tools/regression-gate/README.md
+++ b/tools/regression-gate/README.md
@@ -1,0 +1,74 @@
+# Firmware regression gate
+
+Two diffs between the **old** and **new** resolved firmware config. Run both
+before every release. A clean `esphome compile` is necessary but **not
+sufficient** — it proves the YAML is valid, not that the firmware still behaves
+the same.
+
+## Why the behaviour gate exists
+
+v2.7.0 rewired the Ropener onto `valar-core` as a remote package. The entity
+gate passed perfectly: no entity dropped, renamed, or retyped. It shipped.
+
+But the product's `on_stall` handler had been silently replaced by
+`valar-core`'s default. Two live bugs resulted:
+
+- the device wedged in `HOMING` forever after any home (killing the button
+  gestures and the schedule, both of which guard on `global_state`), and
+- **every** stall zeroed the position, so a curtain snagging mid-travel
+  silently redefined that point as home.
+
+No entity name changed, so nothing caught it. The behaviour gate diffs the
+*automation bodies* — `on_stall`, `on_press`/`on_click`/`on_release`, script
+bodies, `on_boot`, intervals, `*_action`, lambdas — anchored to stable
+identities rather than list positions.
+
+It also caught an unrelated change in the same release: the `Motor Direction`
+option string `"Reversed ↺"` had lost its glyph, which would have broken any
+Home Assistant automation selecting it by value.
+
+## Usage
+
+```sh
+# 1. Resolve both configs (from a checkout of each version)
+esphome config firmware/VAL3100/Ropener-VAL3100.yml > /tmp/old-3100.yaml
+esphome config firmware/VAL3100/Ropener-VAL3100.yml > /tmp/new-3100.yaml
+
+# 2. Diff them
+python tools/regression-gate/gate.py /tmp/old-3100.yaml /tmp/new-3100.yaml
+
+# 3. Inspect anything it flags
+python tools/regression-gate/gate.py /tmp/old-3100.yaml /tmp/new-3100.yaml \
+    --detail on_stall
+```
+
+Exit code `0` = both gates clean, `1` = something differs. **A difference is not
+automatically a failure** — additions and refactors are often intended. The
+gate's job is to guarantee nothing changes *unnoticed*. Every flagged line must
+be explained in the release notes.
+
+Run it for **each board** (VAL3000 and VAL3100); they share a product layer but
+resolve differently.
+
+Requires `pyyaml` — use the interpreter ESPHome is installed under.
+
+## Known-benign differences after the valar-core rewire
+
+Expected when diffing a pre-rewire release (≤ v2.6.4) against a rewired one:
+
+| Anchor | Why |
+|---|---|
+| 7 diagnostic entities added | `valar-core` shared diagnostics (Restart, Uptime, WiFi Signal, ESP Internal Temperature, IP/SSID/MAC) |
+| `esphome:on_boot` split 600 / 400 / -100 | core / product / scheduling layers; relative order preserved |
+| `script:schedule_open`, `script:schedule_close` | scheduling-mixin contract; the `global_state != 3` homing guard moved into these scripts |
+| `datetime:Open Time`/`Close Time` `on_time`, `interval:60s` | now call the schedule scripts instead of inlining `cover.open`/`cover.close` |
+
+Anything **outside** this table needs justification before release.
+
+## Before Glasscalibur
+
+This tool should move to `valar-motion` so both products share one copy rather
+than duplicating it — same rule as the firmware itself. Glasscalibur's overrides
+(limit switches, TMP1075 thermal cutoff, LIS2DH12 tamper, buzzer) carry the same
+silent-replacement risk as `on_stall` did here, and there a dropped thermal
+cutoff or tamper handler is a safety regression, not a UX one.

--- a/tools/regression-gate/gate.py
+++ b/tools/regression-gate/gate.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Firmware regression gate: diff two `esphome config` dumps.
+
+Compiling proves the YAML is valid. It does not prove the firmware still DOES
+what it did. This runs two independent diffs:
+
+  ENTITY GATE      -- every user-facing entity (domain, name, category).
+                      Catches dropped/renamed/added entities, which break
+                      Home Assistant entity_ids.
+
+  BEHAVIOUR GATE   -- the automation bodies attached to those entities
+                      (on_stall, on_press, script bodies, on_boot, intervals,
+                      *_action, lambdas). Catches an entity that survived by
+                      name while its behaviour was silently replaced.
+
+The behaviour gate exists because of the v2.7.0 homing regression: the entity
+gate passed clean while `on_stall` had been swapped for valar-core's default,
+which zeroed the cover's position on every stall. Entity names alone cannot see
+that class of bug.
+
+Usage:
+    python gate.py OLD.yaml NEW.yaml            # human-readable report
+    python gate.py OLD.yaml NEW.yaml --detail ANCHOR_SUBSTRING
+
+Exit code is 0 if both gates are clean, 1 if either reports a difference.
+Differences are not automatically failures -- intended changes must be reviewed
+and called out. The gate's job is to make sure nothing changes UNNOTICED.
+"""
+import argparse, json, sys, yaml
+
+# --- shared loader -----------------------------------------------------------
+
+DOMAINS = [
+    "binary_sensor", "sensor", "text_sensor", "switch", "number", "select",
+    "button", "cover", "light", "datetime", "text", "fan", "lock", "climate",
+    "valve", "event", "update", "stepper", "output", "alarm_control_panel",
+    "media_player",
+]
+
+
+class Loader(yaml.SafeLoader):
+    """SafeLoader that tolerates ESPHome's custom tags (!lambda, !secret, ...)."""
+
+
+def _passthrough(loader, tag_suffix, node):
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    return loader.construct_mapping(node)
+
+
+Loader.add_multi_constructor("!", _passthrough)
+
+
+def load(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        return yaml.load(fh, Loader=Loader)
+
+
+# --- entity gate -------------------------------------------------------------
+
+def entities(cfg):
+    rows = set()
+    for domain in DOMAINS:
+        block = cfg.get(domain)
+        if not isinstance(block, list):
+            continue
+        for item in block:
+            if not isinstance(item, dict):
+                continue
+            if item.get("name") is not None:
+                rows.add(f"{domain}\t{item['name']}\t{item.get('entity_category') or ''}")
+            # Multi-entity platforms (wifi_info, ...) nest one sub-entity per key.
+            for sub in item.values():
+                if isinstance(sub, dict) and "name" in sub:
+                    rows.add(f"{domain}\t{sub['name']}\t{sub.get('entity_category') or ''}")
+    return rows
+
+
+# --- behaviour gate ----------------------------------------------------------
+
+def is_behaviour_key(key):
+    return key.startswith("on_") or key.endswith("_action") or key in (
+        "lambda", "then", "condition")
+
+
+def strip_comments(text):
+    """Drop whole-line C++ comments. Only lines that START with // are removed --
+    a trailing-comment rule would truncate URLs like https://... in literals."""
+    return "\n".join(
+        ln for ln in text.splitlines() if not ln.lstrip().startswith("//"))
+
+
+def canon(obj):
+    """Whitespace- and comment-insensitive, so reformatting or a reworded
+    comment is not reported as a behaviour change."""
+    if isinstance(obj, str):
+        return " ".join(strip_comments(obj).split())
+    if isinstance(obj, list):
+        return [canon(v) for v in obj]
+    if isinstance(obj, dict):
+        return {k: canon(v) for k, v in sorted(obj.items())}
+    return obj
+
+
+def behaviours(cfg):
+    """anchor -> body. Anchors are stable identities (entity name, script id,
+    boot priority) rather than list positions, so a reordered package merge
+    does not look like a change."""
+    out = {}
+
+    def put(anchor, key, body):
+        out[(anchor, key)] = json.dumps(canon(body), sort_keys=True)
+
+    for boot in (cfg.get("esphome") or {}).get("on_boot") or []:
+        if isinstance(boot, dict):
+            put("esphome:on_boot", str(boot.get("priority", "?")), boot.get("then"))
+
+    for scr in cfg.get("script") or []:
+        if isinstance(scr, dict):
+            put(f"script:{scr.get('id','?')}", "then", scr.get("then"))
+
+    for iv in cfg.get("interval") or []:
+        if isinstance(iv, dict):
+            put(f"interval:{iv.get('interval','?')}", "then", iv.get("then"))
+
+    for domain in DOMAINS:
+        block = cfg.get(domain)
+        if not isinstance(block, list):
+            continue
+        for item in block:
+            if not isinstance(item, dict):
+                continue
+            anchor = f"{domain}:{item.get('name') or item.get('id') or '?'}"
+            for key, val in sorted(item.items()):
+                if is_behaviour_key(key):
+                    put(anchor, key, val)
+                elif isinstance(val, dict):
+                    for k2, v2 in sorted(val.items()):
+                        if is_behaviour_key(k2):
+                            put(f"{anchor}.{key}", k2, v2)
+    return out
+
+
+# --- reporting ---------------------------------------------------------------
+
+def report_entities(old, new):
+    removed, added = sorted(old - new), sorted(new - old)
+    print("=" * 72)
+    print("ENTITY GATE")
+    print("=" * 72)
+    if not removed and not added:
+        print("  clean - entity lists identical\n")
+        return True
+    for row in removed:
+        print(f"  REMOVED  {row}")
+    for row in added:
+        print(f"  ADDED    {row}")
+    print(f"\n  {len(removed)} removed, {len(added)} added -- each must be intended and called out.\n")
+    return False
+
+
+def report_behaviours(old, new):
+    changed = sorted(k for k in set(old) & set(new) if old[k] != new[k])
+    dropped = sorted(set(old) - set(new))
+    gained = sorted(set(new) - set(old))
+    print("=" * 72)
+    print("BEHAVIOUR GATE")
+    print("=" * 72)
+    if not changed and not dropped and not gained:
+        print("  clean - all automation bodies identical\n")
+        return True
+    for k in changed:
+        print(f"  CHANGED  {k[0]} :: {k[1]}")
+    for k in dropped:
+        print(f"  DROPPED  {k[0]} :: {k[1]}")
+    for k in gained:
+        print(f"  NEW      {k[0]} :: {k[1]}")
+    print(f"\n  {len(changed)} changed, {len(dropped)} dropped, {len(gained)} new.")
+    print("  Re-run with --detail <anchor> to see the bodies side by side.\n")
+    return False
+
+
+def detail(old, new, needle):
+    for key in sorted(set(old) | set(new)):
+        if needle.lower() not in f"{key[0]} {key[1]}".lower():
+            continue
+        o, n = old.get(key), new.get(key)
+        if o == n:
+            continue
+        print("=" * 72)
+        print(f"{key[0]}  ::  {key[1]}")
+        print("-" * 30 + " OLD " + "-" * 30)
+        print(json.dumps(json.loads(o), indent=2) if o else "(absent)")
+        print("-" * 30 + " NEW " + "-" * 30)
+        print(json.dumps(json.loads(n), indent=2) if n else "(absent)")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("old")
+    ap.add_argument("new")
+    ap.add_argument("--detail", help="show bodies for anchors matching this substring")
+    args = ap.parse_args()
+
+    old_cfg, new_cfg = load(args.old), load(args.new)
+    old_b, new_b = behaviours(old_cfg), behaviours(new_cfg)
+
+    if args.detail:
+        detail(old_b, new_b, args.detail)
+        return 0
+
+    ok_e = report_entities(entities(old_cfg), entities(new_cfg))
+    ok_b = report_behaviours(old_b, new_b)
+    return 0 if (ok_e and ok_b) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes the homing regression shipped in **v2.7.0**. That release has been demoted
to pre-release and `releases/latest` now resolves to **v2.6.4**, so the OTA
button and the valar-flasher are serving known-good firmware while this lands.

## What broke

v2.7.0 rewired the Ropener onto `valar-core` as a remote package. The entity
list came through clean — nothing dropped, renamed, or retyped — so it shipped.
But the product's `on_stall` handler had been silently replaced by core's
default, which zeroes the stepper position on **every** stall.

Two live bugs:

**1. The device wedged in HOMING.** `start_homing` sets `global_state = 3` and
nothing cleared it. After any home the State sensor read `HOMING` forever, the
cover stayed `CLOSING`, every button gesture died (all guard on `state == 0`)
and the schedule refused to run (guards on `state != 3`). The 200 ms completion
poll only handles states 1/2, so it could not recover either. Only the manual
"Start-Stop Homing" button got the unit back.

**2. Any stall corrupted the position reference.** A curtain snagging mid-travel
silently redefined that point as home, poisoning the cover percentage and the
persisted position. v2.6.4 only zeroed during homing.

## The fix

`!extend` **appends** to core's action list rather than replacing it — verified
empirically. Extending alone would have left core's unconditional zeroing firing
*before* the restored handler, so homing would have looked fixed while the
position corruption continued silently.

`!remove` drops core's handler outright, so two ordered entries leave exactly
one `on_stall`:

```yaml
stepper:
  - id: !extend driver
    on_stall: !remove          # delete core's unconditional zeroing
  - id: !extend driver
    on_stall:                  # install the Ropener's conditional handler
```

Kept inside the product layer deliberately: no `valar-core` change, no
`valar-motion` retag, no repin, and no behaviour change for the generic board
builds (which would have lost their zeroing if core's default became a no-op).
Refactoring core to an explicit `on_stall` hook remains optional cleanup.

The resolved handler is byte-identical to v2.6.4, including the non-homing
`else` branch (stop, clear state, publish IDLE, leave position alone).

## Also in this PR

- **Restore the `Reversed ↺` Motor Direction option.** Core had dropped the
  glyph. The string is what Home Assistant automations select by, and existing
  units hold it as persisted state. `options` is a list, so `!extend` would have
  yielded three choices — same remove/re-add pattern.
- **`fw_version` defaults to `dev`** instead of a hardcoded `2.7.0`, so local and
  branch builds stop misreporting. Release builds still get the tag injected via
  `-s fw_version`.
- **`tools/regression-gate/`** — an entity diff **and** a behavioural diff of the
  resolved config (`on_stall`, `on_press`, script bodies, `on_boot`, intervals,
  `*_action`, lambdas), anchored to stable identities so a reordered package
  merge is not noise.

## Why the behavioural gate

The entity gate passed v2.7.0 completely clean. Entity names cannot see a
handler being swapped out. The behavioural gate caught, in order:

1. the `on_stall` regression itself,
2. the Motor Direction glyph change (unrelated, also shipped in v2.7.0),
3. a **missing `else` branch in the first draft of this very fix**.

## Verification

| | VAL3100 | VAL3000 |
|---|---|---|
| `esphome config` | clean | clean |
| Entity gate | 0 removed, 7 added (intended core diagnostics) | identical |
| Behaviour gate | 0 dropped; only the documented scheduling/`on_boot` refactors | identical |
| `on_stall` vs v2.6.4 | identical | identical |
| OTA asset names + button URL | unchanged | unchanged |

`esphome compile` produces a full `firmware.factory.bin` for VAL3100.

The `on_boot` 600/400/-100 split is a benign layer split: `recompute_distance`
is pure math, the position restore keeps its relative order, and tz/sun moves
later by design. The scheduling refactor moved the `global_state != 3` homing
guard into `schedule_open`/`schedule_close` — preserved, not dropped.

## Before this ships as v2.7.1 latest

- [ ] Compile VAL3000 (in progress)
- [ ] **Bench test on real hardware** — flash a VAL3100, home it on a motor, confirm
      homing completes and state clears; confirm a mid-travel stall does not zero
      position. The gate cannot prove StallGuard behaviour on physical hardware.

Units already on v2.7.0 need v2.7.1 to recover; the interim workaround is the
manual "Start-Stop Homing" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)