### PR TITLE
Derive TCOOLTHRS from Speed, and surface StallGuard arming state

### DIFF
--- a/firmware/common/ropener-product.yaml
+++ b/firmware/common/ropener-product.yaml
@@ -47,6 +47,7 @@ esphome:
     - priority: 400.0
       then:
         - script.execute: recompute_distance
+        - script.execute: recompute_tcoolthrs
         - stepper.report_position:
             id: driver
             position: !lambda "return id(global_current_position);"
@@ -106,6 +107,31 @@ stepper:
             - logger.log: "Stall detected outside homing — motor stopped, position unchanged"
 
 script:
+  # Derive TCOOLTHRS from the configured Speed.
+  #
+  # StallGuard only reports while TSTEP <= TCOOLTHRS, and TSTEP is inversely
+  # proportional to velocity. Measured on VAL3000 hardware (microsteps=8),
+  # within 1% from Speed 3000 to 9000 under real curtain load:
+  #
+  #     TSTEP ~= 374000 / Speed
+  #
+  # So the shipped default of TCOOLTHRS=100 arms only above Speed ~3740. Below
+  # that, StallGuard is switched off entirely -- no error, no log line, nothing
+  # in the UI, and homing simply never completes. That is a setting a customer
+  # can reach just by dragging the Speed slider down for a quieter curtain.
+  #
+  # 2x cruise TSTEP arms from half of cruise speed upward at any Speed, which
+  # keeps the deliberate low-velocity cutoff (SG_RESULT is unreliable when slow,
+  # which is what TCOOLTHRS is for) while guaranteeing it actually engages.
+  - id: recompute_tcoolthrs
+    then:
+      - lambda: |-
+          uint32_t sp = id(global_speed) > 0 ? (uint32_t) id(global_speed) : 1;
+          uint32_t v = 748000UL / sp;
+          if (v > 1048575) v = 1048575;      // TCOOLTHRS is a 20-bit register
+          id(global_tcoolthrs) = (int) v;
+          id(driver)->write_register(TCOOLTHRS, v);
+
   # Recompute the derived step cache from the persisted centimeters (one place).
   - id: recompute_distance
     then:
@@ -374,6 +400,12 @@ number:
     name: "TCOOLTHRS value"
   - id: !extend num_sgthrs
     name: "SGTHRS value"
+  # Re-derive TCOOLTHRS whenever Speed changes. !extend APPENDS to core's action
+  # list, which is what we want here: core still stores global_speed and pushes
+  # the new speed to the driver, then this runs.
+  - id: !extend num_speed
+    set_action:
+      - script.execute: recompute_tcoolthrs
   # Product-only: travel distance in centimeters (drives the cover's 0..1 range).
   - platform: template
     name: "Centimeters"
@@ -454,6 +486,35 @@ button:
             - stepper.set_target: { id: driver, target: -100000 }
 
 text_sensor:
+  # Surfaces StallGuard's arming state, which is otherwise invisible. The
+  # failure it exists to catch: if TCOOLTHRS is below the cruise TSTEP for the
+  # configured Speed, StallGuard NEVER reports, homing never completes, and
+  # nothing anywhere says so. Diagnosed here from the configured Speed, so a
+  # misconfiguration is visible while the curtain is standing still rather than
+  # only discovered when homing silently fails.
+  #
+  # "Below threshold" during acceleration is normal and expected -- StallGuard
+  # is deliberately disarmed at low velocity, which is what TCOOLTHRS is for.
+  # A reading that never leaves it once at speed is the real fault.
+  - platform: template
+    name: "StallGuard"
+    id: sg_status
+    icon: "mdi:shield-search"
+    entity_category: DIAGNOSTIC
+    web_server: { sorting_weight: 3, sorting_group_id: group_stallguard }
+    update_interval: 1s
+    lambda: |-
+      const uint32_t tc = id(driver)->read_register(TCOOLTHRS);
+      // Predicted cruise TSTEP for the configured Speed (measured constant).
+      const uint32_t sp = id(global_speed) > 0 ? (uint32_t) id(global_speed) : 1;
+      const uint32_t cruise = 374000UL / sp;
+      if (cruise > tc)
+        return {"Never arms at this Speed"};
+      const uint32_t ts = id(driver)->read_register(TSTEP);
+      if (ts >= 0xFFFFF) return {"Ready (stopped)"};
+      if (ts <= tc)      return {"Armed"};
+      return {"Below threshold"};
+
   - platform: template
     name: "State"
     id: cover_state


### PR DESCRIPTION
First step toward making StallGuard usable without hand-tuning registers. This
is the half that needed **no** guesswork -- it is arithmetic plus a diagnostic.
SGTHRS still depends on installed load and stays manual; that is the calibration
wizard, still to come.

## The bug this fixes

StallGuard only reports while `TSTEP <= TCOOLTHRS`, and TSTEP is inversely
proportional to velocity. Measured on VAL3000 hardware, within 1% from Speed
3000 to 9000 under real curtain load:

```
TSTEP ~= 374000 / Speed        (microsteps=8, as fixed in valar-core)
```

| Speed | TSTEP measured | predicted |
|---|---|---|
| 3000 | 124 | 125 |
| 6000 | 62 | 62.3 |
| 9000 | 41-42 | 41.6 |

So the shipped default **TCOOLTHRS=100 arms only above Speed ~3740.** Below
that StallGuard is off entirely -- no error, no log line, nothing in the UI --
and sensorless homing never completes.

A customer reaches that state just by dragging the Speed slider down for a
quieter curtain. It is also exactly why a bench unit at Speed 1500 looked
broken while the same firmware worked fine at 9000.

## Changes

**`recompute_tcoolthrs`** derives `TCOOLTHRS = 748000 / Speed`, on boot and on
every Speed change. 2x cruise TSTEP arms from half of cruise speed upward at any
Speed. That keeps the deliberate low-velocity cutoff -- SG_RESULT is unreliable
when slow, which is the whole point of TCOOLTHRS -- while guaranteeing it
actually engages.

Hooked via `!extend` on `num_speed`. Unlike `on_stall`, appending is what we
want here: core still stores `global_speed` and pushes the speed to the driver,
then this runs. Verified against the resolved config.

**A `StallGuard` diagnostic text_sensor** reporting `Armed` / `Below threshold`
/ `Ready (stopped)` / `Never arms at this Speed`.

The last state is diagnosed from the *configured Speed*, not live TSTEP, so a
misconfiguration is visible while the curtain is standing still rather than
being discovered when homing silently fails. `Below threshold` during
acceleration is normal and expected -- StallGuard is deliberately disarmed at
low velocity.

## Verified on the installed curtain unit, over OTA

| | |
|---|---|
| Speed 9000 | TCOOLTHRS auto-derives to **83** (was a hand-set 100) |
| Speed 1500 | moves to **498** -- the configuration that was previously dead |
| StallGuard sensor | reports `Ready (stopped)` at rest |

The auto-derived 83 at Speed 9000 lands right next to the 100 that had been
reached by hand, which is a good sign the rule matches what tuning converges on.

## Gates

```
ENTITY     1 added (StallGuard, diagnostic), 0 removed
BEHAVIOUR  esphome:on_boot::400  number:Speed::set_action (appended, core intact)
           + script:recompute_tcoolthrs, text_sensor:StallGuard
```

Nothing dropped. `esphome compile` clean.

## Not in this PR

SGTHRS. Measurements show free-running SG_RESULT runs ~270 at Speed 3000 and
~324-450 at 9000, and a hand-grab on the rope takes it to ~130 and ~32
respectively -- so a single fixed threshold cannot serve the range. The rule
that reproduces the current hand-tuned value is
`SGTHRS ~= free_SG_at_speed * 0.6 / 2` (97 at Speed 9000 vs the 100 in use),
but it needs a measured free-travel baseline at the actual operating point,
which is the wizard.

## Before release

- [ ] Bench: confirm homing still completes at Speed 9000 with auto-derived TCOOLTHRS 83
- [ ] Bench: confirm homing now works at a slow Speed (e.g. 1500) that previously never armed

Aiming for v2.8.0 once those pass.

Generated with [Claude Code](https://claude.com/claude-code)