### PR TITLE
docs: reconcile BOM + Build Guide with v1.2.1 hardware

### DIFF
--- a/docs/BOM-V2.0.md
+++ b/docs/BOM-V2.0.md
@@ -1,6 +1,6 @@
 # BOM V2.0
 
-> Reflects the **v1.1** hardware. What changed from v1.0: a smaller-diameter **MK8** drive gear (pull strength 11 lb → 15 lb), **one larger 633ZZ bearing per arm** instead of two small bearings, and **pre-cut PTFE tubes** (no razor-cutting). Quantities are per unit. Every purchasable part links to the [Valar Systems store](https://valarsystems.com).
+> Reflects the current **v1.2.1** hardware. Notable changes since v1.0: a smaller-diameter **MK8** drive gear (pull strength 11 lb → 15 lb), **one larger 633ZZ bearing per arm** instead of two small bearings, **pre-cut PTFE tubes** (no razor-cutting), **foam mounting squares** in place of adhesive command strips, and a **24 V 1.5 A** power adapter. Quantities are per unit. Every purchasable part links to the [Valar Systems store](https://valarsystems.com).
 
 ## Body Assembly
 
@@ -25,15 +25,17 @@
 | PTFE tubing, 3 mm ID × 5 mm OD (pre-cut) | 6 | 2 × 10 mm, 2 × 40 mm, 2 × 70 mm — [buy](https://valarsystems.com/products/ptfe-tube). |
 | M3 × 10 mm screw, self-tapping | 14 | [Thread-forming screw](https://valarsystems.com/products/m3-x-10mm-thread-forming-screw). |
 | M3 square nut | 1 | [Curtain-pulley nut](https://valarsystems.com/products/m3-square-nut). |
-| Zip tie | 1 | Small, 2–3 mm wide — [buy](https://valarsystems.com/products/zip-tie). |
+| Zip tie | 4 | Small, 2–3 mm wide. One for the motor-side rope elbow, one for the far-side pulley, and two for attaching carriages to ring curtains (one per carriage) — [buy](https://valarsystems.com/products/zip-tie). |
 | V623ZZ pulley | 1 | 3 × 12 × 4 mm — [V-groove pulley](https://valarsystems.com/products/v-groove-pulley). |
 | Rope | 1 | 1.6 mm diameter — [buy](https://valarsystems.com/products/rope). |
+
+> **Carriages:** the standard build uses **two** carriages (one with a single top screw, one with two). How many carriages a multi-panel curtain needs is not documented yet — **TODO**.
 
 ### Mounting Hardware
 
 | Part | Qty | Description |
 | :--- | :---: | :--- |
-| Foam mounting squares (set of 5) | 5 | 1" square double-sided foam. Wipe the surface clean and dry, then press firmly — [buy](https://valarsystems.com/products/foam-mounting-squares). |
+| Foam mounting square, 1" | 5 | Double-sided; **five squares per unit**. Wipe the surface clean and dry, then press firmly — [buy](https://valarsystems.com/products/foam-mounting-squares). |
 
 ## Assembly Tools Required
 

--- a/docs/wiki-Build-Guide.md
+++ b/docs/wiki-Build-Guide.md
@@ -6,12 +6,12 @@
 
 Assembling a Ropener takes about **20 minutes** with three common hand tools — no soldering. It comes together in three stages: the **motor body**, the **curtain-rail carriages**, and **attaching it to your curtains**. Follow whichever guide below suits you — they all cover the same build.
 
-> 🆕 **New in v1.1** — This guide covers the current **v1.1** hardware:
+> 🆕 **Current hardware — v1.2.1.** Notable changes since v1.0:
 > - **Stronger pull (11 lb → 15 lb)** from a smaller-diameter **MK8** drive gear (replaces the MK7).
 > - **One larger 633ZZ bearing (3 × 13 × 5 mm) per arm** instead of two small bearings.
 > - **Pre-cut PTFE tubes** (10 / 40 / 70 mm) — no measuring or razor-cutting.
 >
-> Print from [`hardware/plastics/v1.1`](https://github.com/Valar-Systems/Ropener/tree/main/hardware/plastics/v1.1). The v1.0 files remain in the repo for anyone who already built one.
+> Print from [`hardware/plastics/v1.2.1`](https://github.com/Valar-Systems/Ropener/tree/main/hardware/plastics/v1.2.1). Earlier revisions remain in the repo for anyone who already built one.
 
 ## How to build
 
@@ -87,7 +87,7 @@ Everything the build needs is below. For the full, maintained list see the [Bill
 | NEMA 17 stepper motor | 1 |
 | 24 V 1.5 A power adapter | 1 |
 | Cable extension | as needed |
-| Foam mounting squares (set of 5) | 5 |
+| Foam mounting square, 1" | 5 |
 | 1.6 mm rope | 30 ft |
 | PTFE tubing (pre-cut: 2 × 10 mm, 2 × 40 mm, 2 × 70 mm) | 6 |
 | M3 square nut | 4 |
@@ -153,6 +153,8 @@ This device works on the following curtain types.
 ## Curtain rail assembly
 
 > **Overview.** Along the rod, from one end to the other, you'll have: the **pulley**, a **carriage with one screw on top**, a **carriage with two screws on top**, and the **motor-side** anchor.
+
+> **How many carriages?** The standard build uses **two** (one single-screw, one double-screw). How carriage count should scale as the number of curtain panels grows is not documented yet — **TODO**.
 
 <!-- 📷 media/build-guide/15-setup-overview.png — rail layout: pulley, 1-screw carriage, 2-screw carriage, motor side -->
 


### PR DESCRIPTION
Makes `docs/BOM-V2.0.md` and `docs/wiki-Build-Guide.md` agree with each other and with the shipped **v1.2.1** hardware. Where the two files disagreed and I wasn't told which was right, I stopped rather than picking — see the open question below.

## Applied
1. **Zip ties** — BOM `1 → 4`, breakdown spelled out (1 motor-side elbow + 1 far-side pulley + 2 ring-curtain carriages). The wiki already said 4; now they match.
2. **Version header** — BOM `v1.1 → v1.2.1` (change list expanded to include foam squares + 24 V). Wiki "New in v1.1" banner → "Current hardware — v1.2.1", and its print link **hardware/plastics/v1.1 → v1.2.1** (the old path was broken — the folder is `v1.1.0`, and v1.2.1 is what ships).
5. **Foam row** — "Foam mounting squares (set of 5) | 5" was ambiguous → **"Foam mounting square, 1" | 5"** + "five squares per unit", both files.
7. **Carriages** — added a note to both files: standard build = **two** carriages (one single-screw, one double-screw). No carriages-per-panel rule exists anywhere in the repo, so I left a **TODO** rather than invent a ratio.

Regenerated `dist/` docx + PDF from the edited BOM source (gitignored, not in this PR).

## Report-only (no silent edits)
3. **Assembly time** — already consistent: every in-repo doc says **20 minutes** (`wiki-Build-Guide:7`, `wiki-Home:22`, `README:45`). The only "hours" is 3D-print time (~9 h). Any "1–2 hours" lives in external materials outside this repo. No change needed.
6. **Thread-forming screws** — the two files agree at **22** (8 body + 14 curtain), but the **Build Guide steps do not sum to 22** as written:
   - Body: **8** ✓ — Step 2 (PCB→wall-plate) 4 + Step 3 (wall-plate→housing) 4. (Step 1's "two black M3×10" I read as the 2 flat-head machine screws, not thread-forming.)
   - Curtain rail: only **7** explicitly — Step 1 (long tubes) 2 + Step 2 (pulley end) 1 + Step 3 (carriage sides) 4.
   - Unaccounted toward the BOM's 14: the carriages' "1 + 2 screws on top" (3), any carriage tension screws, and back-tab clamp screws (unspecified, curtain-type-dependent) are **not enumerated** in the steps.
   - **Total explicitly called for ≈ 15, not 22.** Flagging per instructions — not editing either file to force a match. The gap is the Build Guide's curtain steps being incomplete, not a BOM/wiki disagreement.

## ⛔ Open question — item 4 (tool count), NOT changed
The wiki lists **three** tools (Phillips #1, 2 mm hex, **1.5 mm hex**) and says "three common hand tools"; the BOM lists **two** (Phillips #1, 2 mm hex). Walking the steps, only two are actually called for: Phillips for the plastic thread-forming screws, 2 mm hex for the M3 button-head screws. **No step references a 1.5 mm hex or any grub/set screw** — the only plausible use is a set screw on the MK8 drive gear (Step 4 just says "fit onto the motor shaft"). Need your call before editing either file — see PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)