### PR TITLE
docs: BOM/Build-Guide follow-ups missed by #41 (1.5 mm hex + screw tally)

### DIFF
--- a/docs/BOM-V2.0.md
+++ b/docs/BOM-V2.0.md
@@ -42,4 +42,5 @@
 | Part | Qty | Description |
 | :--- | :---: | :--- |
 | Screwdriver, Phillips No. 1 | 1 | [Phillips No. 1](https://valarsystems.com/products/phillips-no-1-screw-driver). |
-| Hex driver, 2 mm | 1 | [2 mm hex driver](https://valarsystems.com/products/allen-wrench-2mm). |
+| Hex driver, 2 mm | 1 | For the M3 button-head screws — [2 mm hex driver](https://valarsystems.com/products/allen-wrench-2mm). |
+| Hex driver, 1.5 mm | 1 | For the MK8 drive-gear set screw. |

--- a/docs/BOM-V2.0.md
+++ b/docs/BOM-V2.0.md
@@ -43,4 +43,4 @@
 | :--- | :---: | :--- |
 | Screwdriver, Phillips No. 1 | 1 | [Phillips No. 1](https://valarsystems.com/products/phillips-no-1-screw-driver). |
 | Hex driver, 2 mm | 1 | For the M3 button-head screws — [2 mm hex driver](https://valarsystems.com/products/allen-wrench-2mm). |
-| Hex driver, 1.5 mm | 1 | For the MK8 drive-gear set screw. |
+| Hex driver, 1.5 mm | 1 | For the MK8 drive-gear set screw — [1.5 mm hex driver](https://valarsystems.com/products/allen-wrench-1-5mm). |

--- a/docs/wiki-Build-Guide.md
+++ b/docs/wiki-Build-Guide.md
@@ -173,7 +173,9 @@ The **PTFE tubes come pre-cut** — no cutting needed. You'll have **two of each
 2. **Pulley end.** Fit the **short tubes**, then the **V-groove pulley** held by an **M3 × 15 mm button-head screw**, secured with an **M3 square nut** and an **M3 thread-forming screw**.
 
 <!-- 📷 media/build-guide/18-carriages-medium.png — 1 medium tube per carriage, top plastic over tubes, 4 side screws -->
-3. **Carriages.** Place **one medium tube** into each carriage, set the top plastic over the tubes, and drive **four M3 thread-forming screws** into the sides.
+3. **Carriages — build two.** For **each** carriage, place **one medium tube** in, set the top plastic over the tubes, and drive **four M3 thread-forming screws into the sides** (four per carriage, **eight total**). Then add the **top screws that tell the two carriages apart — one on the first carriage, two on the second** (**three total**); these become the rope clamp/tension screws later (see [Rope routing and tensioning](#rope-routing-and-tensioning)).
+
+> **Curtain-side screw count:** 2 (long tubes) + 1 (pulley end) + 8 (carriage sides) + 3 (carriage tops) = **14 M3 × 10 thread-forming screws**. With the **8** in the motor body, a full build uses **22** — matching the [Bill of Materials](https://github.com/Valar-Systems/Ropener/blob/main/docs/BOM-V2.0.md).
 
 ---
 

--- a/docs/wiki-Build-Guide.md
+++ b/docs/wiki-Build-Guide.md
@@ -130,8 +130,8 @@ This device works on the following curtain types.
 <!-- 📷 media/build-guide/07-wallplate-buttons.png — buttons in holes, wall plate attached with 4 screws -->
 3. **Fit the buttons and close the body.** Place the buttons into their holes, then attach the wall plate to the housing using **four M3 thread-forming screws**.
 
-<!-- 📷 media/build-guide/08-drive-pulley.png — drive pulley on motor shaft -->
-4. **Attach the drive pulley.** Fit it onto the motor shaft. You'll fine-tune its position later.
+<!-- 📷 media/build-guide/08-drive-pulley.png — MK8 drive gear on motor shaft, set screw tightened with 1.5 mm hex -->
+4. **Attach the drive gear.** Fit the **MK8 drive gear** onto the motor shaft and secure it with its **set screw, using the 1.5 mm hex driver**. Snug it just enough to hold position — you'll fine-tune the position later before fully tightening.
 
 <!-- 📷 media/build-guide/09-arms.png — arm with M3×15mm button head (red), one 633ZZ bearing (green), M3 square nut (orange) -->
 5. **Assemble the two arms.** Each arm uses an **M3 × 15 mm button-head screw**, **one 633ZZ bearing (3 × 13 × 5 mm)**, and an **M3 square nut**. **On one of the two arms, also seat a third M3 square nut into its pocket now** — that pocket is inaccessible once the arms are mated, and the **M3 × 35 mm clamp screw** in Step 8 threads into this nut to pull the arm pair against the drive pulley. Build both arms the same way.


### PR DESCRIPTION
**PR #41 was merged when the branch only had its first commit** (`32df276`, items 1/2/5/7), so three commits that were pushed to that branch afterward never reached `main`. This brings them in — no new work, just the stranded commits:

1. **Item 4 — 1.5 mm hex** (owner-confirmed: MK8 drive-gear set screw). Adds the `Hex driver, 1.5 mm` row to the BOM's Assembly Tools, and Build Guide **Step 4** now says to fit the **MK8 drive gear** and tighten its **set screw with the 1.5 mm hex** (was "fit the drive pulley", no set-screw mention).
2. **1.5 mm hex store link** — `valarsystems.com/products/allen-wrench-1-5mm`.
3. **Item 6 enumeration** — the Build Guide's curtain steps now visibly total **14** M3×10 thread-forming screws: 2 (long tubes) + 1 (pulley) + 8 (carriage sides, 4 per carriage) + 3 (carriage tops) = 14, + 8 body = 22, matching the BOM.

Cherry-picked onto current `main`; merges cleanly (main already has `32df276` via #41). `dist/` docx/PDF already regenerated from this BOM (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)